### PR TITLE
Beta-loading-skeleton

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,20 @@
 export default {
   indexHtml: './index.html',
-  menu: ['Home', 'Button','CheckboxGroup','Display Card', 'Dropdown','Form', 'Input', 'Loading Skeleton', 'Modal', 'Panel','RadioGroup', 'Table', 'Tag'],
+  menu: [
+    'Home', 
+    'Button',
+    'CheckboxGroup',
+    'Display Card', 
+    'Dropdown',
+    'Form', 
+    'Input', 
+    'Loading Skeleton', 
+    'Modal', 
+    'Panel',
+    'RadioGroup', 
+    'Table', 
+    'Tag'
+  ],
   themeConfig: {
     styles: {
       body: {

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
   indexHtml: './index.html',
-  menu: ['Home', 'Button', 'Input','Display Card', 'Dropdown', 'CheckboxGroup', 'RadioGroup', 'Form', 'Modal', 'Panel', 'Table', 'Tag'],
+  menu: ['Home', 'Button','CheckboxGroup','Display Card', 'Dropdown','Form', 'Input', 'Loading Skeleton', 'Modal', 'Panel','RadioGroup', 'Table', 'Tag'],
   themeConfig: {
     styles: {
       body: {

--- a/src/pages/loadingskeleton/LoadingSkeleton.state.js
+++ b/src/pages/loadingskeleton/LoadingSkeleton.state.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { DisplayCard, MenuButtons } from 'synapsefi-dev-ui';
+
+const GridWrapper = styled.div`
+  display: grid;
+  grid-gap: 16px;
+  grid-template-columns: repeat(3, 300px);
+  grid-auto-rows: 200px;
+  grid-auto-columns: 200px;
+`;
+
+  const DisplayCardContainer = () => {
+    return (
+      <GridWrapper>
+         <DisplayCard 
+          title="Regular Title"
+          data={
+            [
+              { label: 'Account Name', value: 1234567890 },
+              { label: 'Current Balance', value: '$4.50' },
+            ]
+          }
+          tooltip="Collateral account used for chargebacks and unathorized returns."
+          buttonComponent={(
+            <MenuButtons
+              data={
+                [
+                  { text: 'test click', onClick: () => console.log('test click') },
+                  { text: 'test click 2', onClick: () => console.log('test click 2') },
+                ]
+              }
+            />
+          )}
+        />
+        <DisplayCard
+          title="Regular Title"
+          isActive
+          data={
+            [
+              { label: 'Account Name', value: 1234567890 },
+              { label: 'Current Balance', value: '$4.50' },
+            ]
+          }
+        />
+      </GridWrapper>
+    )
+}
+export default DisplayCardContainer;

--- a/src/pages/loadingskeleton/LoadingSkeleton.state.js
+++ b/src/pages/loadingskeleton/LoadingSkeleton.state.js
@@ -5,7 +5,7 @@ const LoadingSkeletonContainer = () => {
   return (
     <LoadingSkeleton 
       height='100px'
-      width='840px'
+      width='420px'
       borderRadius='10px'
     />
   )

--- a/src/pages/loadingskeleton/LoadingSkeleton.state.js
+++ b/src/pages/loadingskeleton/LoadingSkeleton.state.js
@@ -1,50 +1,13 @@
 import React from 'react';
-import styled from 'styled-components';
+import { LoadingSkeleton } from 'synapsefi-dev-ui';
 
-import { DisplayCard, MenuButtons } from 'synapsefi-dev-ui';
-
-const GridWrapper = styled.div`
-  display: grid;
-  grid-gap: 16px;
-  grid-template-columns: repeat(3, 300px);
-  grid-auto-rows: 200px;
-  grid-auto-columns: 200px;
-`;
-
-  const DisplayCardContainer = () => {
-    return (
-      <GridWrapper>
-         <DisplayCard 
-          title="Regular Title"
-          data={
-            [
-              { label: 'Account Name', value: 1234567890 },
-              { label: 'Current Balance', value: '$4.50' },
-            ]
-          }
-          tooltip="Collateral account used for chargebacks and unathorized returns."
-          buttonComponent={(
-            <MenuButtons
-              data={
-                [
-                  { text: 'test click', onClick: () => console.log('test click') },
-                  { text: 'test click 2', onClick: () => console.log('test click 2') },
-                ]
-              }
-            />
-          )}
-        />
-        <DisplayCard
-          title="Regular Title"
-          isActive
-          data={
-            [
-              { label: 'Account Name', value: 1234567890 },
-              { label: 'Current Balance', value: '$4.50' },
-            ]
-          }
-        />
-      </GridWrapper>
-    )
+const LoadingSkeletonContainer = () => {
+  return (
+    <LoadingSkeleton 
+      height='100px'
+      width='840px'
+      borderRadius='10px'
+    />
+  )
 }
-export default DisplayCardContainer;
+export default LoadingSkeletonContainer;

--- a/src/pages/loadingskeleton/loadingSkeleton.mdx
+++ b/src/pages/loadingskeleton/loadingSkeleton.mdx
@@ -18,11 +18,12 @@ import LoadingSkeletonContainer from './LoadingSkeleton.state.js'
   borderRadius='10px'
 />
 ```
+
 ## Props
 
 | Property                | Type                    | Required  | Description                                 |
 | :-------                | :---                    | :-------  | :----------                                 |
-| height                  | `strin`                 | false     | Height of LoadingSkeleton, defaults to 100%              |
+| height                  | `string`                 | false     | Height of LoadingSkeleton, defaults to 100%              |
 | width                   | `string`                | false     | Width of LoadingSkeleton, defaults to 100%                   |
 | borderRadius            | `string`                | false     | Border-radius of LoadingSkeleton, defaults to 0px     |
 

--- a/src/pages/loadingskeleton/loadingSkeleton.mdx
+++ b/src/pages/loadingskeleton/loadingSkeleton.mdx
@@ -1,0 +1,39 @@
+---
+name: Loading Skeleton
+route: /loadingskeleton
+
+---
+
+# Loading Skeleton
+
+
+
+## Basic
+
+<div>
+  test
+</div>
+
+
+```jsx
+test
+```
+## Props
+
+| Property                | Type                    | Required  | Description                                 |
+| :-------                | :---                    | :-------  | :----------                                 |
+| isActive                | `bool`                  | false     | Green border appears if active              |
+| title                   | `string`                | false     | Defines title of the card                   |
+| buttonComponent         | `component`             | false     | The three dot button right of the title     |
+| innerButtonData         | `object`                | false     | Inner block button, data has to be empty    |
+| innerButtonData.text    | `string`                | false     | The title represents information a user would like to include                   |
+| innerButtonData.onClick | `function`              | false     | A function which gets called after the title is clicked on                 |
+| data                    | `objects`               | false     | label, value, isEllipsis list               |
+| label                   | `string`                | false     | Defines label for the account name          |
+| value                   | `string`                | false     | Defines value for the account name                                       |
+| children                | `htmlelement`           | false     | Html element nested in the component. Not recommended with innerButtonData or data.                |
+| isEllipsis              | `bool`                  | false     | Determines if value will have css ellispse properties |
+| tooltip                 | `string`                | false     | Will render the Tooltip component            |
+| isDisabled              | `bool`                  | false     | Disables the button Component                |
+| className               | `string`                | false     | Class Name for css customization             |
+

--- a/src/pages/loadingskeleton/loadingSkeleton.mdx
+++ b/src/pages/loadingskeleton/loadingSkeleton.mdx
@@ -1,39 +1,28 @@
 ---
 name: Loading Skeleton
 route: /loadingskeleton
-
 ---
+
+import LoadingSkeletonContainer from './LoadingSkeleton.state.js'
 
 # Loading Skeleton
 
-
-
 ## Basic
 
-<div>
-  test
-</div>
-
+<LoadingSkeletonContainer />
 
 ```jsx
-test
+<LoadingSkeleton 
+  height='100px'
+  width='840px'
+  borderRadius='10px'
+/>
 ```
 ## Props
 
 | Property                | Type                    | Required  | Description                                 |
 | :-------                | :---                    | :-------  | :----------                                 |
-| isActive                | `bool`                  | false     | Green border appears if active              |
-| title                   | `string`                | false     | Defines title of the card                   |
-| buttonComponent         | `component`             | false     | The three dot button right of the title     |
-| innerButtonData         | `object`                | false     | Inner block button, data has to be empty    |
-| innerButtonData.text    | `string`                | false     | The title represents information a user would like to include                   |
-| innerButtonData.onClick | `function`              | false     | A function which gets called after the title is clicked on                 |
-| data                    | `objects`               | false     | label, value, isEllipsis list               |
-| label                   | `string`                | false     | Defines label for the account name          |
-| value                   | `string`                | false     | Defines value for the account name                                       |
-| children                | `htmlelement`           | false     | Html element nested in the component. Not recommended with innerButtonData or data.                |
-| isEllipsis              | `bool`                  | false     | Determines if value will have css ellispse properties |
-| tooltip                 | `string`                | false     | Will render the Tooltip component            |
-| isDisabled              | `bool`                  | false     | Disables the button Component                |
-| className               | `string`                | false     | Class Name for css customization             |
+| height                  | `strin`                 | false     | Height of LoadingSkeleton, defaults to 100%              |
+| width                   | `string`                | false     | Width of LoadingSkeleton, defaults to 100%                   |
+| borderRadius            | `string`                | false     | Border-radius of LoadingSkeleton, defaults to 0px     |
 


### PR DESCRIPTION
**Task Link:** https://synapsepay.monday.com/boards/180157847/pulses/371815143

**Description:**

LoadingSkeleton

Added the LoadingSkeleton component into the dev-ui-docz

The DocZ file displays a basic LoadingSkeleton with a specified height, width, and borderRadius

Props display all the necessary information the render the LoadingSkeleton

**Updates:**
none

**Notes:**
none

**Visuals:**
![LS-basic](https://user-images.githubusercontent.com/36527396/68722626-e97a4c80-056a-11ea-88f2-de555d7903f2.png)
